### PR TITLE
doc: add 'pict-tag'

### DIFF
--- a/ppict.scrbl
+++ b/ppict.scrbl
@@ -473,6 +473,15 @@ Returns a pict like @racket[p] that carries a symbolic tag. The tag
 can be used with @racket[find-tag] to locate the pict.
 }
 
+@defproc[(pict-tag [p pict?]) (or/c symbol? #f)]{
+Return the symbolic tag carried by @racket[p].
+
+@examples[#:eval the-eval
+  (pict-tag (blank))
+  (pict-tag (tag-pict (blank) 'a-blank))
+]
+}
+
 @defproc[(find-tag [p pict?] [find tag-path?])
          (or/c pict-path? #f)]{
 


### PR DESCRIPTION
Add a `defproc` for the exported-but-undocumented `pict-tag` function.

Today `pict-tag` helped me change the code for the top picture to code that can also make the bottom picture:
![pict-tag-example](https://user-images.githubusercontent.com/1731829/46980768-acabff80-d0a3-11e8-9cb8-c601b2e54a87.png)

